### PR TITLE
PR template tweaks. Use stable tag of minotaur configs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,12 +11,12 @@ Closes #XXX <!-- TODO: Please link the issue requesting the package here. -->
 
 ## PR Checklist
 
-- [ ] Add the appropriate label to your PR (`new package` or `package_update`).
+- [ ] Add the appropriate label to your PR (`new package` or `package update`).
 - [ ] The PR title is in the format `Add/update package: {package_name}`.
 - [ ] The PR description includes a link to the issue requesting the package its
       update. (Add to `Closes #XXX` above.)
 
-If adding a package:
+If adding or updating a package:
 
 - [ ] This PR contains a sequencingSourceFile (`.ssf`) for the requested
       package.

--- a/assets/template.config
+++ b/assets/template.config
@@ -1,7 +1,8 @@
 // Keep track of config versions
+minotaur_release='0.2.1' // The release tag of the poseidon-eager repository used for processing and config file retrieval
 config_template_version='0.3.0dev'
 package_config_version='0.3.0dev'
-minotaur_config_base='https://raw.githubusercontent.com/poseidon-framework/poseidon-eager/main/conf'
+minotaur_config_base="https://raw.githubusercontent.com/poseidon-framework/poseidon-eager/${minotaur_release}/conf"
 
 // This configuration file is designed to be a used with the nf-core/eager pipeline.
 //   Instead of having to specify all other configurations for the Minotaur pipeline


### PR DESCRIPTION
Adds:
- Use stable version of configs based on poseidon-eager release tags.
- Minor tweaks to PR Template